### PR TITLE
Allow shorturls to end in /. Fixes #164

### DIFF
--- a/froide/foirequest/tests/test_web.py
+++ b/froide/foirequest/tests/test_web.py
@@ -171,9 +171,12 @@ class WebTest(TestCase):
         self.assertEqual(response.status_code, 404)
         response = self.client.get(reverse('foirequest-shortlink',
                 kwargs={"obj_id": req.id}))
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response['Location'].endswith(req.get_absolute_url()))
-        req.visibility = 1
+        self.assertRedirects(response, req.get_absolute_url())
+        # Shortlinks may end in /
+        response = self.client.get(reverse('foirequest-shortlink',
+                kwargs={"obj_id": req.id}) + '/')
+        self.assertRedirects(response, req.get_absolute_url())
+        req.visibility = FoiRequest.VISIBLE_TO_REQUESTER
         req.save()
         response = self.client.get(reverse('foirequest-shortlink',
                 kwargs={"obj_id": req.id}))

--- a/froide/urls.py
+++ b/froide/urls.py
@@ -86,7 +86,7 @@ urlpatterns += patterns('',
     # Translators: request URL
     url(r'^%s/' % _('request'), include('froide.foirequest.request_urls')),
     # Translators: Short-request URL
-    url(r"^%s/(?P<obj_id>\d+)$" % _('r'), 'froide.foirequest.views.shortlink', name="foirequest-shortlink"),
+    url(r"^%s/(?P<obj_id>\d+)/?$" % _('r'), 'froide.foirequest.views.shortlink', name="foirequest-shortlink"),
     # Translators: Short-request auth URL
     url(r"^%s/(?P<obj_id>\d+)/auth/(?P<code>[0-9a-f]+)/$" % _('r'), 'froide.foirequest.views.auth', name="foirequest-auth"),
     # Translators: follow request URL


### PR DESCRIPTION
Also makes use of django.test.SimpleTestCase.assertRedirects in test.