### PR TITLE
Froide is not compatible with django 1.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pip==8.1.1
-Django<1.10
+Django==1.8
 Markdown==2.6.6
 celery==3.1.23
 django-haystack==2.5.dev1


### PR DESCRIPTION
Hence changed the requirements.txt file. This is due to the `patterns` module, deprecated in 1.8 already.

http://stackoverflow.com/questions/8074955/cannot-import-name-patterns